### PR TITLE
Refactor emissivity IMC-DDMC interface/boundary condition.

### DIFF
--- a/GRID/leakage_opacity1.f90
+++ b/GRID/leakage_opacity1.f90
@@ -141,8 +141,8 @@ subroutine leakage_opacity1
 !
         if(lhelp) then
 !-- DDMC interface
-           help = (grd_cap(ig,l)+grd_sig(l))*dx(i)*thelp
-           pp = 4d0/(3d0*help+6d0*pc_dext)
+           pp = ddmc_emiss_bc(dx(i)*thelp, grd_fcoef(l), &
+                grd_cap(ig,l), grd_sig(l), pc_dext)
            grd_opaclump(1,l)=grd_opaclump(1,l)+(specval*speclump)*&
                 1.5d0*pp*grd_xarr(i)**2/(dx3(i)*thelp)
         else
@@ -165,8 +165,8 @@ subroutine leakage_opacity1
 !
         if(lhelp) then
 !-- DDMC interface
-           help = (grd_cap(ig,l)+grd_sig(l))*dx(i)*thelp
-           pp = 4d0/(3d0*help+6d0*pc_dext)
+           pp = ddmc_emiss_bc(dx(i)*thelp, grd_fcoef(l), &
+                grd_cap(ig,l), grd_sig(l), pc_dext)
            grd_opaclump(2,l)=grd_opaclump(2,l)+(specval*speclump)*&
                 1.5d0*pp*grd_xarr(i+1)**2/(dx3(i)*thelp)
         else
@@ -189,8 +189,8 @@ subroutine leakage_opacity1
 !
         if(lhelp) then
 !-- DDMC interface
-           help = (grd_cap(ig,l)+grd_sig(l))*xm(i)*dyac(j)*thelp
-           pp = 4d0/(3d0*help+6d0*pc_dext)
+           pp = ddmc_emiss_bc(xm(i)*dyac(j)*thelp, grd_fcoef(l), &
+                grd_cap(ig,l), grd_sig(l), pc_dext)
            grd_opaclump(3,l)=grd_opaclump(3,l)+(specval*speclump)*&
                 0.75d0*pp*dx2(i)*sqrt(1d0-grd_yarr(j)**2)/(dy(j)*dx3(i)*thelp)
         else
@@ -214,8 +214,8 @@ subroutine leakage_opacity1
 !
         if(lhelp) then
 !-- DDMC interface
-           help = (grd_cap(ig,l)+grd_sig(l))*xm(i)*dyac(j)*thelp
-           pp = 4d0/(3d0*help+6d0*pc_dext)
+           pp = ddmc_emiss_bc(xm(i)*dyac(j)*thelp, grd_fcoef(l), &
+                grd_cap(ig,l), grd_sig(l), pc_dext)
            grd_opaclump(4,l)=grd_opaclump(4,l)+(specval*speclump)*&
                 0.75d0*pp*dx2(i)*sqrt(1d0-grd_yarr(j+1)**2)/(dy(j)*dx3(i)*thelp)
         else
@@ -242,9 +242,8 @@ subroutine leakage_opacity1
 !
         if(lhelp) then
 !-- DDMC interface
-           help = (grd_cap(ig,l)+grd_sig(l))*xm(i)*ym(j) * &
-              dz(k)*thelp
-           pp = 4d0/(3d0*help+6d0*pc_dext)
+           pp = ddmc_emiss_bc(xm(i)*ym(j)*dz(k)*thelp, grd_fcoef(l), &
+                grd_cap(ig,l), grd_sig(l), pc_dext)
            grd_opaclump(5,l)=grd_opaclump(5,l)+(specval*speclump)*&
                 0.75d0*pp*dx2(i)*dyac(j)/(dy(j)*dx3(i)*dz(k)*thelp)
         else
@@ -269,9 +268,8 @@ subroutine leakage_opacity1
 !
         if(lhelp) then
 !-- DDMC interface
-           help = (grd_cap(ig,l)+grd_sig(l))*xm(i)*ym(j) * &
-              dz(k)*thelp
-           pp = 4d0/(3d0*help+6d0*pc_dext)
+           pp = ddmc_emiss_bc(xm(i)*ym(j)*dz(k)*thelp, grd_fcoef(l), &
+                grd_cap(ig,l), grd_sig(l), pc_dext)
            grd_opaclump(6,l)=grd_opaclump(6,l)+(specval*speclump)*&
                 0.75d0*pp*dx2(i)*dyac(j)/(dy(j)*dx3(i)*dz(k)*thelp)
         else

--- a/GRID/leakage_opacity11.f90
+++ b/GRID/leakage_opacity11.f90
@@ -120,8 +120,8 @@ subroutine leakage_opacity11
 !
         if(lhelp) then
 !-- DDMC interface
-           help = (grd_cap(ig,l)+grd_sig(l))*dx(i)*thelp
-           ppl = 4d0/(3d0*help+6d0*pc_dext)
+           ppl = ddmc_emiss_bc(dx(i)*thelp, grd_fcoef(l), &
+                grd_cap(ig,l), grd_sig(l), pc_dext)
            grd_opaclump(1,l)=grd_opaclump(1,l)+(specval*speclump)*&
                 1.5d0*ppl*(thelp*grd_xarr(i))**2/ &
                 (3d0*grd_vol(l)/pc_pi4)
@@ -145,8 +145,8 @@ subroutine leakage_opacity11
 !
         if(lhelp) then
 !-- DDMC interface
-           help = (grd_cap(ig,l)+grd_sig(l))*dx(i)*thelp
-           ppr = 4d0/(3d0*help+6d0*pc_dext)
+           ppr = ddmc_emiss_bc(dx(i)*thelp, grd_fcoef(l), &
+                grd_cap(ig,l), grd_sig(l), pc_dext)
            grd_opaclump(2,l)=grd_opaclump(2,l)+(specval*speclump)*&
                 1.5d0*ppr*(thelp*grd_xarr(i+1))**2/ &
                 (3d0*grd_vol(l)/pc_pi4)

--- a/GRID/leakage_opacity2.f90
+++ b/GRID/leakage_opacity2.f90
@@ -138,8 +138,8 @@ subroutine leakage_opacity2
 !
         if(lhelp) then
 !-- DDMC interface
-           help = (grd_cap(ig,l)+grd_sig(l))*dx(i)*thelp
-           ppl = 4d0/(3d0*help+6d0*pc_dext)
+           ppl = ddmc_emiss_bc(dx(i)*thelp, grd_fcoef(l), &
+                grd_cap(ig,l), grd_sig(l), pc_dext)
            grd_opaclump(1,l)=grd_opaclump(1,l)+(specval*speclump)*&
                 ppl*(thelp*grd_xarr(i))/(dx2(i)*thelp**2)
         else
@@ -162,8 +162,8 @@ subroutine leakage_opacity2
 !
         if(lhelp) then
 !-- DDMC interface
-           help = (grd_cap(ig,l)+grd_sig(l))*dx(i)*thelp
-           ppr = 4d0/(3d0*help+6d0*pc_dext)
+           ppr = ddmc_emiss_bc(dx(i)*thelp, grd_fcoef(l), &
+                grd_cap(ig,l), grd_sig(l), pc_dext)
            grd_opaclump(2,l)=grd_opaclump(2,l)+(specval*speclump)*&
                 ppr*(thelp*grd_xarr(i+1))/(dx2(i)*thelp**2)
         else
@@ -186,8 +186,8 @@ subroutine leakage_opacity2
 !
         if(lhelp) then
 !-- DDMC interface
-           help = (grd_cap(ig,l)+grd_sig(l))*dy(j)*thelp
-           ppl = 4d0/(3d0*help+6d0*pc_dext)
+           ppl = ddmc_emiss_bc(dy(j)*thelp, grd_fcoef(l), &
+                grd_cap(ig,l), grd_sig(l), pc_dext)
            grd_opaclump(3,l)=grd_opaclump(3,l)+(specval*speclump)*&
                 0.5d0*ppl/(thelp*dy(j))
         else
@@ -210,8 +210,8 @@ subroutine leakage_opacity2
 !
         if(lhelp) then
 !-- DDMC interface
-           help = (grd_cap(ig,l)+grd_sig(l))*dy(j)*thelp
-           ppr = 4d0/(3d0*help+6d0*pc_dext)
+           ppr = ddmc_emiss_bc(dy(j)*thelp, grd_fcoef(l), &
+                grd_cap(ig,l), grd_sig(l), pc_dext)
            grd_opaclump(4,l)=grd_opaclump(4,l)+(specval*speclump)*&
                 0.5d0*ppr/(thelp*dy(j))
         else
@@ -237,9 +237,8 @@ subroutine leakage_opacity2
 
         if(lhelp) then
 !-- DDMC interface
-           help = (grd_cap(ig,l)+grd_sig(l))*xm(i) * &
-              dz(k)*thelp
-           ppl = 4d0/(3d0*help+6d0*pc_dext)
+           ppl = ddmc_emiss_bc(xm(i)*dz(k)*thelp, grd_fcoef(l), &
+                grd_cap(ig,l), grd_sig(l), pc_dext)
            grd_opaclump(5,l)=grd_opaclump(5,l)+(specval*speclump)*&
               0.5d0*ppl/(xm(i)*dz(k)*thelp)
         else
@@ -263,9 +262,8 @@ subroutine leakage_opacity2
 
         if(lhelp) then
 !-- DDMC interface
-           help = (grd_cap(ig,l)+grd_sig(l))*xm(i) * &
-              dz(k)*thelp
-           ppr = 4d0/(3d0*help+6d0*pc_dext)
+           ppr = ddmc_emiss_bc(xm(i)*dz(k)*thelp, grd_fcoef(l), &
+                grd_cap(ig,l), grd_sig(l), pc_dext)
            grd_opaclump(6,l)=grd_opaclump(6,l)+(specval*speclump)*&
               0.5d0*ppr/(xm(i)*dz(k)*thelp)
         else

--- a/GRID/leakage_opacity3.f90
+++ b/GRID/leakage_opacity3.f90
@@ -127,14 +127,8 @@ subroutine leakage_opacity3
 !
         if(lhelp) then
 !-- DDMC interface
-           help = (grd_cap(ig,l)+grd_sig(l))*dx(i)*thelp
-           alb = grd_fcoef(l)*grd_cap(ig,l)/ &
-                (grd_cap(ig,l)+grd_sig(l))
-           eps = (4d0/3d0)*sqrt(3d0*alb)/(1d0+pc_dext*sqrt(3d0*alb))
-           beta = 1.5d0*alb*help**2+sqrt(3d0*alb*help**2 + &
-                2.25d0*alb**2*help**4)
-           pp = 0.5d0*eps*beta/(beta-0.75*eps*help)
-!              pp = 4d0/(3d0*help+6d0*pc_dext)
+           pp = ddmc_emiss_bc(dx(i)*thelp, grd_fcoef(l), &
+                grd_cap(ig,l), grd_sig(l), pc_dext)
            grd_opaclump(1,l) = grd_opaclump(1,l)+(specval*speclump)*&
                 0.5d0*pp/(thelp*dx(i))
         else
@@ -157,14 +151,8 @@ subroutine leakage_opacity3
 !
         if(lhelp) then
 !-- DDMC interface
-           help = (grd_cap(ig,l)+grd_sig(l))*dx(i)*thelp
-           alb = grd_fcoef(l)*grd_cap(ig,l)/ &
-                (grd_cap(ig,l)+grd_sig(l))
-           eps = (4d0/3d0)*sqrt(3d0*alb)/(1d0+pc_dext*sqrt(3d0*alb))
-           beta = 1.5d0*alb*help**2+sqrt(3d0*alb*help**2 + &
-                2.25d0*alb**2*help**4)
-           pp = 0.5d0*eps*beta/(beta-0.75*eps*help)
-!              pp = 4d0/(3d0*help+6d0*pc_dext)
+           pp = ddmc_emiss_bc(dx(i)*thelp, grd_fcoef(l), &
+                grd_cap(ig,l), grd_sig(l), pc_dext)
            grd_opaclump(2,l) = grd_opaclump(2,l)+(specval*speclump)*&
                 0.5d0*pp/(thelp*dx(i))
         else
@@ -187,14 +175,8 @@ subroutine leakage_opacity3
 !
         if(lhelp) then
 !-- DDMC interface
-           help = (grd_cap(ig,l)+grd_sig(l))*dy(j)*thelp
-           alb = grd_fcoef(l)*grd_cap(ig,l)/ &
-                (grd_cap(ig,l)+grd_sig(l))
-           eps = (4d0/3d0)*sqrt(3d0*alb)/(1d0+pc_dext*sqrt(3d0*alb))
-           beta = 1.5d0*alb*help**2+sqrt(3d0*alb*help**2 + &
-                2.25d0*alb**2*help**4)
-           pp = 0.5d0*eps*beta/(beta-0.75*eps*help)
-!              pp = 4d0/(3d0*help+6d0*pc_dext)
+           pp = ddmc_emiss_bc(dy(j)*thelp, grd_fcoef(l), &
+                grd_cap(ig,l), grd_sig(l), pc_dext)
            grd_opaclump(3,l) = grd_opaclump(3,l)+(specval*speclump)*&
                 0.5d0*pp/(thelp*dy(j))
         else
@@ -217,14 +199,8 @@ subroutine leakage_opacity3
 !
         if(lhelp) then
 !-- DDMC interface
-           help = (grd_cap(ig,l)+grd_sig(l))*dy(j)*thelp
-           alb = grd_fcoef(l)*grd_cap(ig,l)/ &
-                (grd_cap(ig,l)+grd_sig(l))
-           eps = (4d0/3d0)*sqrt(3d0*alb)/(1d0+pc_dext*sqrt(3d0*alb))
-           beta = 1.5d0*alb*help**2+sqrt(3d0*alb*help**2 + &
-                2.25d0*alb**2*help**4)
-           pp = 0.5d0*eps*beta/(beta-0.75*eps*help)
-!              pp = 4d0/(3d0*help+6d0*pc_dext)
+           pp = ddmc_emiss_bc(dy(j)*thelp, grd_fcoef(l), &
+                grd_cap(ig,l), grd_sig(l), pc_dext)
            grd_opaclump(4,l) = grd_opaclump(4,l)+(specval*speclump)*&
                 0.5d0*pp/(thelp*dy(j))
         else
@@ -247,14 +223,8 @@ subroutine leakage_opacity3
 !
         if(lhelp) then
 !-- DDMC interface
-           help = (grd_cap(ig,l)+grd_sig(l))*dz(k)*thelp
-           alb = grd_fcoef(l)*grd_cap(ig,l)/ &
-                (grd_cap(ig,l)+grd_sig(l))
-           eps = (4d0/3d0)*sqrt(3d0*alb)/(1d0+pc_dext*sqrt(3d0*alb))
-           beta = 1.5d0*alb*help**2+sqrt(3d0*alb*help**2 + &
-                2.25d0*alb**2*help**4)
-           pp = 0.5d0*eps*beta/(beta-0.75*eps*help)
-!              pp = 4d0/(3d0*help+6d0*pc_dext)
+           pp = ddmc_emiss_bc(dz(k)*thelp, grd_fcoef(l), &
+                grd_cap(ig,l), grd_sig(l), pc_dext)
            grd_opaclump(5,l) = grd_opaclump(5,l)+(specval*speclump)*&
                 0.5d0*pp/(thelp*dz(k))
         else
@@ -277,14 +247,8 @@ subroutine leakage_opacity3
 !
         if(lhelp) then
 !-- DDMC interface
-           help = (grd_cap(ig,l)+grd_sig(l))*dz(k)*thelp
-           alb = grd_fcoef(l)*grd_cap(ig,l)/ &
-                (grd_cap(ig,l)+grd_sig(l))
-           eps = (4d0/3d0)*sqrt(3d0*alb)/(1d0+pc_dext*sqrt(3d0*alb))
-           beta = 1.5d0*alb*help**2+sqrt(3d0*alb*help**2 + &
-                2.25d0*alb**2*help**4)
-           pp = 0.5d0*eps*beta/(beta-0.75*eps*help)
-!              pp = 4d0/(3d0*help+6d0*pc_dext)
+           pp = ddmc_emiss_bc(dz(k)*thelp, grd_fcoef(l), &
+                grd_cap(ig,l), grd_sig(l), pc_dext)
            grd_opaclump(6,l) = grd_opaclump(6,l)+(specval*speclump)*&
                 0.5d0*pp/(thelp*dz(k))
         else

--- a/SOURCE/interior_source.f90
+++ b/SOURCE/interior_source.f90
@@ -107,11 +107,11 @@ subroutine interior_source
 !-- calculating direction cosine (comoving)
      call rnd_r(r1,rnd_state)
      mu0 = 1d0-2d0*r1
-     ptcl%mu = mu0 !overwrite when isvelocity
+     ptcl%mu = mu0
 !-- sampling azimuthal angle of direction
      call rnd_r(r1,rnd_state)
      om0 = pc_pi2*r1
-     ptcl%om = om0 !overwrite when isvelocity
+     ptcl%om = om0
 
 !
 !-- x position
@@ -146,7 +146,7 @@ subroutine interior_source
   enddo !j
   enddo !k
   if(ipart/=src_nsurf+src_nnonth) stop 'interior_source: n/=nexecsrc'
-  
+
 
 !-- Thermal volume particle instantiation: loop
   iimpi = -1

--- a/TRANSPORT1/diffusion1.f90
+++ b/TRANSPORT1/diffusion1.f90
@@ -210,8 +210,8 @@ pure subroutine diffusion1(ptcl,ptcl2,cache,rndstate,edep,eraddens,totevelo,ierr
      endif
      if(lhelp) then
 !-- DDMC interface
-        mfphelp = (grd_cap(ig,ic)+grd_sig(ic))*dx(ix)*thelp
-        pp = 4d0/(3d0*mfphelp+6d0*pc_dext)
+        pp = ddmc_emiss_bc(dx(ix)*thelp, grd_fcoef(ic), &
+             grd_cap(ig,ic), grd_sig(ic), pc_dext)
         opacleak(1)=1.5d0*pp*grd_xarr(ix)**2/(dx3(ix)*thelp)
      else
 !-- DDMC interior
@@ -232,8 +232,8 @@ pure subroutine diffusion1(ptcl,ptcl2,cache,rndstate,edep,eraddens,totevelo,ierr
      endif
      if(lhelp) then
 !-- DDMC interface
-        mfphelp = (grd_cap(ig,ic)+grd_sig(ic))*dx(ix)*thelp
-        pp = 4d0/(3d0*mfphelp+6d0*pc_dext)
+        pp = ddmc_emiss_bc(dx(ix)*thelp, grd_fcoef(ic), &
+             grd_cap(ig,ic), grd_sig(ic), pc_dext)
         opacleak(2)=1.5d0*pp*grd_xarr(ix+1)**2/(dx3(ix)*thelp)
      else
 !-- DDMC interior
@@ -255,8 +255,8 @@ pure subroutine diffusion1(ptcl,ptcl2,cache,rndstate,edep,eraddens,totevelo,ierr
 !
      if(lhelp) then
 !-- DDMC interface
-        mfphelp = (grd_cap(ig,ic)+grd_sig(ic))*xm(ix)*dyac(iy)*thelp
-        pp = 4d0/(3d0*mfphelp+6d0*pc_dext)
+        pp = ddmc_emiss_bc(xm(ix)*dyac(iy)*thelp, grd_fcoef(ic), &
+             grd_cap(ig,ic), grd_sig(ic), pc_dext)
         opacleak(3)=0.75d0*pp*dx2(ix)*sqrt(1d0-grd_yarr(iy)**2) / &
              (dy(iy)*dx3(ix)*thelp)
      else
@@ -280,8 +280,8 @@ pure subroutine diffusion1(ptcl,ptcl2,cache,rndstate,edep,eraddens,totevelo,ierr
 !
      if(lhelp) then
 !-- DDMC interface
-        mfphelp = (grd_cap(ig,ic)+grd_sig(ic))*xm(ix)*dyac(iy)*thelp
-        pp = 4d0/(3d0*mfphelp+6d0*pc_dext)
+        pp = ddmc_emiss_bc(xm(ix)*dyac(iy)*thelp, grd_fcoef(ic), &
+             grd_cap(ig,ic), grd_sig(ic), pc_dext)
         opacleak(4)=0.75d0*pp*dx2(ix)*sqrt(1d0-grd_yarr(iy+1)**2) / &
              (dy(iy)*dx3(ix)*thelp)
      else
@@ -315,9 +315,8 @@ pure subroutine diffusion1(ptcl,ptcl2,cache,rndstate,edep,eraddens,totevelo,ierr
 !
         if(lhelp) then
 !-- DDMC interface
-           mfphelp = (grd_cap(ig,ic)+grd_sig(ic))*xm(ix)*ym(iy) * &
-              dz(iz)*thelp
-           pp = 4d0/(3d0*mfphelp+6d0*pc_dext)
+           pp = ddmc_emiss_bc(xm(ix)*ym(iy)*dz(iz)*thelp, grd_fcoef(ic), &
+                grd_cap(ig,ic), grd_sig(ic), pc_dext)
            opacleak(5)=0.75d0*pp*dx2(ix)*dyac(iy) / &
                 (dy(iy)*dx3(ix)*dz(iz)*thelp)
         else
@@ -344,9 +343,8 @@ pure subroutine diffusion1(ptcl,ptcl2,cache,rndstate,edep,eraddens,totevelo,ierr
 !
         if(lhelp) then
 !-- DDMC interface
-           mfphelp = (grd_cap(ig,ic)+grd_sig(ic))*xm(ix)*ym(iy) * &
-              dz(iz)*thelp
-           pp = 4d0/(3d0*mfphelp+6d0*pc_dext)
+           pp = ddmc_emiss_bc(xm(ix)*ym(iy)*dz(iz)*thelp, grd_fcoef(ic), &
+                grd_cap(ig,ic), grd_sig(ic), pc_dext)
            opacleak(6)=0.75d0*pp*dx2(ix)*dyac(iy) / &
                 (dy(iy)*dx3(ix)*dz(iz)*thelp)
         else
@@ -531,9 +529,8 @@ pure subroutine diffusion1(ptcl,ptcl2,cache,rndstate,edep,eraddens,totevelo,ierr
                    dz(iz))*thelp<trn_tauddmc
            if(lhelp) then
 !-- DDMC interface
-              mfphelp = (grd_cap(iiig,ic)+grd_sig(ic)) * &
-                   dx(ix)*thelp
-              pp = 4d0/(3d0*mfphelp+6d0*pc_dext)
+              pp = ddmc_emiss_bc(dx(ix)*thelp, grd_fcoef(ic), &
+                   grd_cap(iiig,ic), grd_sig(ic), pc_dext)
               resopacleak = 1.5d0*pp*grd_xarr(ix)**2/(dx3(ix)*thelp)
            else
 !-- IMC interface
@@ -623,9 +620,8 @@ pure subroutine diffusion1(ptcl,ptcl2,cache,rndstate,edep,eraddens,totevelo,ierr
            endif
            if(lhelp) then
 !-- DDMC interface
-              mfphelp = (grd_cap(iiig,ic)+grd_sig(ic)) * &
-                   dx(ix)*thelp
-              pp = 4d0/(3d0*mfphelp+6d0*pc_dext)
+              pp = ddmc_emiss_bc(dx(ix)*thelp, grd_fcoef(ic), &
+                   grd_cap(iiig,ic), grd_sig(ic), pc_dext)
               resopacleak = 1.5d0*pp*grd_xarr(ix+1)**2/(dx3(ix)*thelp)
            else
 !-- IMC interface
@@ -744,9 +740,8 @@ pure subroutine diffusion1(ptcl,ptcl2,cache,rndstate,edep,eraddens,totevelo,ierr
                 thelp<trn_tauddmc
            if(lhelp) then
 !-- DDMC interface
-              mfphelp = (grd_cap(iiig,ic)+grd_sig(ic)) * &
-                   xm(ix)*dyac(iy)*thelp
-              pp = 4d0/(3d0*mfphelp+6d0*pc_dext)
+              pp = ddmc_emiss_bc(xm(ix)*dyac(iy)*thelp, grd_fcoef(ic), &
+                   grd_cap(iiig,ic), grd_sig(ic), pc_dext)
               resopacleak=0.75d0*pp*dx2(ix)*sqrt(1d0-grd_yarr(iy)**2) / &
                    (dy(iy)*dx3(ix)*thelp)
            else
@@ -851,9 +846,8 @@ pure subroutine diffusion1(ptcl,ptcl2,cache,rndstate,edep,eraddens,totevelo,ierr
                 thelp<trn_tauddmc
            if(lhelp) then
 !-- DDMC interface
-              mfphelp = (grd_cap(iiig,ic)+grd_sig(ic)) * &
-                   xm(ix)*dyac(iy)*thelp
-              pp = 4d0/(3d0*mfphelp+6d0*pc_dext)
+              pp = ddmc_emiss_bc(xm(ix)*dyac(iy)*thelp, grd_fcoef(ic), &
+                   grd_cap(iiig,ic), grd_sig(ic), pc_dext)
               resopacleak=0.75d0*pp*dx2(ix)*sqrt(1d0-grd_yarr(iy+1)**2) / &
                    (dy(iy)*dx3(ix)*thelp)
            else
@@ -960,9 +954,8 @@ pure subroutine diffusion1(ptcl,ptcl2,cache,rndstate,edep,eraddens,totevelo,ierr
 !
            if(lhelp) then
 !-- DDMC interface
-              mfphelp = (grd_cap(iiig,ic)+grd_sig(ic)) * &
-                   xm(ix)*ym(iy)*dz(iz)*thelp
-              pp = 4d0/(3d0*mfphelp+6d0*pc_dext)
+              pp = ddmc_emiss_bc(xm(ix)*ym(iy)*dz(iz)*thelp, grd_fcoef(ic), &
+                   grd_cap(iiig,ic), grd_sig(ic), pc_dext)
               resopacleak=0.75d0*pp*dx2(ix)*dyac(iy) / &
                    (dy(iy)*dx3(ix)*dz(iz)*thelp)
            else
@@ -1073,9 +1066,8 @@ pure subroutine diffusion1(ptcl,ptcl2,cache,rndstate,edep,eraddens,totevelo,ierr
 !
            if(lhelp) then
 !-- DDMC interface
-              mfphelp = (grd_cap(iiig,ic)+grd_sig(ic)) * &
-                   xm(ix)*ym(iy)*dz(iz)*thelp
-              pp = 4d0/(3d0*mfphelp+6d0*pc_dext)
+              pp = ddmc_emiss_bc(xm(ix)*ym(iy)*dz(iz)*thelp, grd_fcoef(ic), &
+                   grd_cap(iiig,ic), grd_sig(ic), pc_dext)
               resopacleak=0.75d0*pp*dx2(ix)*dyac(iy) / &
                    (dy(iy)*dx3(ix)*dz(iz)*thelp)
            else

--- a/TRANSPORT1/diffusion11.f90
+++ b/TRANSPORT1/diffusion11.f90
@@ -194,8 +194,8 @@ pure subroutine diffusion11(ptcl,ptcl2,cache,rndstate,edep,eraddens,totevelo,ier
      elseif((grd_cap(ig,l)+ &
           grd_sig(l))*dx(ix-1)*thelp<trn_tauddmc) then
 !-- DDMC interface
-        mfphelp = (grd_cap(ig,ic)+grd_sig(ic))*dx(ix)*thelp
-        ppl = 4d0/(3d0*mfphelp+6d0*pc_dext)
+        ppl = ddmc_emiss_bc(dx(ix)*thelp, grd_fcoef(ic), &
+             grd_cap(ig,ic), grd_sig(ic), pc_dext)
         opacleak(1)= 1.5d0*ppl*(thelp*grd_xarr(ix))**2/ &
              (thelp**3*dx3(ix))
      else
@@ -217,8 +217,8 @@ pure subroutine diffusion11(ptcl,ptcl2,cache,rndstate,edep,eraddens,totevelo,ier
 !
      if(lhelp) then
 !-- DDMC interface
-        mfphelp = (grd_cap(ig,ic)+grd_sig(ic))*dx(ix)*thelp
-        ppr = 4d0/(3d0*mfphelp+6d0*pc_dext)
+        ppr = ddmc_emiss_bc(dx(ix)*thelp, grd_fcoef(ic), &
+             grd_cap(ig,ic), grd_sig(ic), pc_dext)
         opacleak(2)=1.5d0*ppr*(thelp*grd_xarr(ix+1))**2/ &
              (thelp**3*dx3(ix))
      else
@@ -388,8 +388,8 @@ pure subroutine diffusion11(ptcl,ptcl2,cache,rndstate,edep,eraddens,totevelo,ier
               if((grd_cap(iiig,l)+ &
                    grd_sig(l))*dx(ix-1)*thelp<trn_tauddmc) then
 !-- DDMC interface
-                 mfphelp = (grd_cap(iiig,ic)+grd_sig(ic))*dx(ix)*thelp
-                 ppl = 4d0/(3d0*mfphelp+6d0*pc_dext)
+                 ppl = ddmc_emiss_bc(dx(ix)*thelp, grd_fcoef(ic), &
+                      grd_cap(iiig,ic), grd_sig(ic), pc_dext)
                  resopacleak = 1.5d0*ppl*(thelp*grd_xarr(ix))**2/ &
                       (thelp**3*dx3(ix))
               else
@@ -448,8 +448,8 @@ pure subroutine diffusion11(ptcl,ptcl2,cache,rndstate,edep,eraddens,totevelo,ier
               specig = cache%specarr(iiig)
               !specig = specint0(grd_tempinv(ic),iiig)
 !-- calculating resolved leakage opacities
-              mfphelp = (grd_cap(iiig,ic)+grd_sig(ic))*dx(ix)*thelp
-              ppr = 4d0/(3d0*mfphelp+6d0*pc_dext)
+              ppr = ddmc_emiss_bc(dx(ix)*thelp, grd_fcoef(ic), &
+                   grd_cap(iiig,ic), grd_sig(ic), pc_dext)
               resopacleak = 1.5d0*ppr*(thelp*grd_xarr(ix+1))**2/ &
                    (thelp**3*dx3(ix))
               denom2 = denom2+specig*resopacleak*speclump*help
@@ -497,8 +497,8 @@ pure subroutine diffusion11(ptcl,ptcl2,cache,rndstate,edep,eraddens,totevelo,ier
               if((grd_cap(iiig,l)+ &
                    grd_sig(l))*dx(ix+1)*thelp<trn_tauddmc) then
 !-- DDMC interface
-                 mfphelp = (grd_cap(iiig,ic)+grd_sig(ic))*dx(ix)*thelp
-                 ppr = 4d0/(3d0*mfphelp+6d0*pc_dext)
+                 ppr = ddmc_emiss_bc(dx(ix)*thelp, grd_fcoef(ic), &
+                      grd_cap(iiig,ic), grd_sig(ic), pc_dext)
                  resopacleak = 1.5d0*ppr*(thelp*grd_xarr(ix+1))**2/ &
                       (thelp**3*dx3(ix))
               else

--- a/TRANSPORT1/transport1.f90
+++ b/TRANSPORT1/transport1.f90
@@ -719,9 +719,8 @@ pure subroutine transport1(ptcl,ptcl2,rndstate,edep,eraddens,eamp,totevelo,ierr)
               e = e*(1d0+2d0*(0.55d0*help-1.25d0*abs(mu))*x*cinv)
            endif
         endif
-        help = (grd_cap(ig,l)+grd_sig(l)) * &
-             dx(ixnext)*thelp
-        help = 4d0/(3d0*help+6d0*pc_dext)
+        help = ddmc_emiss_bc(dx(ixnext)*thelp, grd_fcoef(l), &
+             grd_cap(ig,l), grd_sig(l), pc_dext)
 !-- sampling
         call rnd_r(r1,rndstate)
         if(r1<help*(1d0+1.5d0*abs(mu))) then
@@ -772,9 +771,8 @@ pure subroutine transport1(ptcl,ptcl2,rndstate,edep,eraddens,eamp,totevelo,ierr)
            mu=(mu-x*cinv)/(1d0-x*mu*cinv)
         endif
         eta = sqrt(1d0-mu**2)*cos(om)
-        help = (grd_cap(ig,l)+grd_sig(l)) * &
-             xm(ix)*dyac(iynext)*thelp
-        help = 4d0/(3d0*help+6d0*pc_dext)
+        help = ddmc_emiss_bc(xm(ix)*dyac(iynext)*thelp, grd_fcoef(l), &
+             grd_cap(ig,l), grd_sig(l), pc_dext)
 !-- sampling
         call rnd_r(r1,rndstate)
         if(r1 < help*(1d0+1.5d0*abs(eta))) then
@@ -847,9 +845,8 @@ pure subroutine transport1(ptcl,ptcl2,rndstate,edep,eraddens,eamp,totevelo,ierr)
            mu = (mu-x*cinv)/elabfact
            xi = sqrt(1d0-mu**2)*sin(om)
         endif
-        help = (grd_cap(ig,l)+grd_sig(l)) * &
-             xm(ix)*ym(iy)*dz(iznext)*thelp
-        help = 4d0/(3d0*help+6d0*pc_dext)
+        help = ddmc_emiss_bc(xm(ix)*ym(iy)*dz(iznext)*thelp, grd_fcoef(l), &
+             grd_cap(ig,l), grd_sig(l), pc_dext)
 !-- sampling
         call rnd_r(r1,rndstate)
         if (r1 < help*(1d0+1.5d0*abs(xi))) then

--- a/TRANSPORT1/transport11.f90
+++ b/TRANSPORT1/transport11.f90
@@ -290,8 +290,8 @@ pure subroutine transport11(ptcl,ptcl2,rndstate,edep,eraddens,eamp,totevelo,ierr
         ic = grd_icell(ix,iy,iz)
      else
 !-- DDMC in adjacent cell
-        help= (grd_cap(ig,l)+grd_sig(l))*dx(ix+1)*thelp
-        help = 4d0/(3d0*help+6d0*pc_dext)
+        help = ddmc_emiss_bc(dx(ix+1)*thelp, grd_fcoef(l), &
+                grd_cap(ig,l), grd_sig(l), pc_dext)
 !-- sampling
         call rnd_r(r1,rndstate)
         if (r1 < help*(1d0+1.5*abs(mu))) then
@@ -321,8 +321,8 @@ pure subroutine transport11(ptcl,ptcl2,rndstate,edep,eraddens,eamp,totevelo,ierr
         ic = grd_icell(ix,iy,iz)
      else
 !-- DDMC in adjacent cell
-        help = (grd_cap(ig,l)+grd_sig(l))*dx(ix-1)*thelp
-        help = 4d0/(3d0*help+6d0*pc_dext)
+        help = ddmc_emiss_bc(dx(ix-1)*thelp, grd_fcoef(l), &
+                grd_cap(ig,l), grd_sig(l), pc_dext)
 !-- sampling
         call rnd_r(r1,rndstate)
         if (r1 < help*(1d0+1.5d0*abs(mu))) then

--- a/TRANSPORT2/diffusion2.f90
+++ b/TRANSPORT2/diffusion2.f90
@@ -207,8 +207,8 @@ pure subroutine diffusion2(ptcl,ptcl2,cache,rndstate,edep,eraddens,totevelo,ierr
         grd_sig(l))*min(dx(ix-1),dy(iy))* &
         thelp<trn_tauddmc) then
 !-- DDMC interface
-        mfphelp = (grd_cap(ig,ic)+grd_sig(ic))*dx(ix)*thelp
-        pp = 4d0/(3d0*mfphelp+6d0*pc_dext)
+        pp = ddmc_emiss_bc(dx(ix)*thelp, grd_fcoef(ic), &
+             grd_cap(ig,ic), grd_sig(ic), pc_dext)
         opacleak(1)= pp*(thelp*grd_xarr(ix))/ &
              (thelp**2*dx2(ix))
      else
@@ -230,8 +230,8 @@ pure subroutine diffusion2(ptcl,ptcl2,cache,rndstate,edep,eraddens,totevelo,ierr
      endif
      if(lhelp) then
 !-- DDMC interface
-        mfphelp = (grd_cap(ig,ic)+grd_sig(ic))*dx(ix)*thelp
-        pp = 4d0/(3d0*mfphelp+6d0*pc_dext)
+        pp = ddmc_emiss_bc(dx(ix)*thelp, grd_fcoef(ic), &
+             grd_cap(ig,ic), grd_sig(ic), pc_dext)
         opacleak(2)= pp*(thelp*grd_xarr(ix+1))/ &
              (thelp**2*dx2(ix))
      else
@@ -253,8 +253,8 @@ pure subroutine diffusion2(ptcl,ptcl2,cache,rndstate,edep,eraddens,totevelo,ierr
      endif
      if(lhelp) then
 !-- DDMC interface
-        mfphelp = (grd_cap(ig,ic)+grd_sig(ic))*dy(iy)*thelp
-        pp = 4d0/(3d0*mfphelp+6d0*pc_dext)
+        pp = ddmc_emiss_bc(dy(iy)*thelp, grd_fcoef(ic), &
+             grd_cap(ig,ic), grd_sig(ic), pc_dext)
         opacleak(3)=0.5d0*pp/(thelp*dy(iy))
      else
 !-- DDMC interior
@@ -274,8 +274,8 @@ pure subroutine diffusion2(ptcl,ptcl2,cache,rndstate,edep,eraddens,totevelo,ierr
      endif
      if(lhelp) then
 !-- DDMC interface
-        mfphelp = (grd_cap(ig,ic)+grd_sig(ic))*dy(iy)*thelp
-        pp = 4d0/(3d0*mfphelp+6d0*pc_dext)
+        pp = ddmc_emiss_bc(dy(iy)*thelp, grd_fcoef(ic), &
+             grd_cap(ig,ic), grd_sig(ic), pc_dext)
         opacleak(4)=0.5d0*pp/(thelp*dy(iy))
      else
 !-- DDMC interior
@@ -307,9 +307,8 @@ pure subroutine diffusion2(ptcl,ptcl2,cache,rndstate,edep,eraddens,totevelo,ierr
 
         if(lhelp) then
 !-- DDMC interface
-           mfphelp = (grd_cap(ig,ic)+grd_sig(ic))*xm(ix) * &
-              dz(iz)*thelp
-           pp = 4d0/(3d0*mfphelp+6d0*pc_dext)
+           pp = ddmc_emiss_bc(xm(ix)*dz(iz)*thelp, grd_fcoef(ic), &
+                grd_cap(ig,ic), grd_sig(ic), pc_dext)
            opacleak(5)=.5d0*pp/(xm(ix)*dz(iz)*thelp)
         else
 !-- DDMC interior
@@ -335,9 +334,8 @@ pure subroutine diffusion2(ptcl,ptcl2,cache,rndstate,edep,eraddens,totevelo,ierr
 
         if(lhelp) then
 !-- DDMC interface
-           mfphelp = (grd_cap(ig,ic)+grd_sig(ic))*xm(ix) * &
-              dz(iz)*thelp
-           pp = 4d0/(3d0*mfphelp+6d0*pc_dext)
+           pp = ddmc_emiss_bc(xm(ix)*dz(iz)*thelp, grd_fcoef(ic), &
+                grd_cap(ig,ic), grd_sig(ic), pc_dext)
            opacleak(6)=.5d0*pp/(xm(ix)*dz(iz)*thelp)
         else
 !-- DDMC interior
@@ -514,9 +512,8 @@ pure subroutine diffusion2(ptcl,ptcl2,cache,rndstate,edep,eraddens,totevelo,ierr
                 grd_sig(l))*min(dx(ix-1),dy(iy),xm(ix-1)*dz(iz)) * &
                 thelp<trn_tauddmc) then
 !-- IMC interface
-              mfphelp = (grd_cap(iiig,ic)+grd_sig(ic)) * &
-                   dx(ix)*thelp
-              pp = 4d0/(3d0*mfphelp+6d0*pc_dext)
+              pp = ddmc_emiss_bc(dx(ix)*thelp, grd_fcoef(ic), &
+                   grd_cap(iiig,ic), grd_sig(ic), pc_dext)
               resopacleak = pp*(thelp*grd_xarr(ix))/ &
                    (thelp**2*dx2(ix))
            else
@@ -592,9 +589,8 @@ pure subroutine diffusion2(ptcl,ptcl2,cache,rndstate,edep,eraddens,totevelo,ierr
            endif
            if(lhelp) then
 !-- IMC interface or boundary
-              mfphelp = (grd_cap(iiig,ic)+grd_sig(ic)) * &
-                   dx(ix)*thelp
-              pp = 4d0/(3d0*mfphelp+6d0*pc_dext)
+              pp = ddmc_emiss_bc(dx(ix)*thelp, grd_fcoef(ic), &
+                   grd_cap(iiig,ic), grd_sig(ic), pc_dext)
               resopacleak = pp*(thelp*grd_xarr(ix+1))/ &
                    (thelp**2*dx2(ix))
            else
@@ -707,9 +703,8 @@ pure subroutine diffusion2(ptcl,ptcl2,cache,rndstate,edep,eraddens,totevelo,ierr
            endif
            if(lhelp) then
 !-- IMC interface or boundary
-              mfphelp = (grd_cap(iiig,ic)+grd_sig(ic)) * &
-                   dy(iy)*thelp
-              pp = 4d0/(3d0*mfphelp+6d0*pc_dext)
+              pp = ddmc_emiss_bc(dy(iy)*thelp, grd_fcoef(ic), &
+                   grd_cap(iiig,ic), grd_sig(ic), pc_dext)
               resopacleak = 0.5d0*pp/(thelp*dy(iy))
            else
 !-- DDMC interface
@@ -822,9 +817,8 @@ pure subroutine diffusion2(ptcl,ptcl2,cache,rndstate,edep,eraddens,totevelo,ierr
            endif
            if(lhelp) then
 !-- IMC interface or boundary
-              mfphelp = (grd_cap(iiig,ic)+grd_sig(ic)) * &
-                   dy(iy)*thelp
-              pp = 4d0/(3d0*mfphelp+6d0*pc_dext)
+              pp = ddmc_emiss_bc(dy(iy)*thelp, grd_fcoef(ic), &
+                   grd_cap(iiig,ic), grd_sig(ic), pc_dext)
               resopacleak = 0.5d0*pp/(thelp*dy(iy))
            else
 !-- DDMC interface
@@ -943,9 +937,8 @@ pure subroutine diffusion2(ptcl,ptcl2,cache,rndstate,edep,eraddens,totevelo,ierr
                 thelp<trn_tauddmc
            if(lhelp) then
 !-- DDMC interface
-              mfphelp = (grd_cap(iiig,ic)+grd_sig(ic)) * &
-                   xm(ix)*dz(iz)*thelp
-              pp = 4d0/(3d0*mfphelp+6d0*pc_dext)
+              pp = ddmc_emiss_bc(xm(ix)*dz(iz)*thelp, grd_fcoef(ic), &
+                   grd_cap(iiig,ic), grd_sig(ic), pc_dext)
               resopacleak=.5d0*pp/(xm(ix)*dz(iz)*thelp)
            else
 !-- DDMC interior
@@ -1034,9 +1027,8 @@ pure subroutine diffusion2(ptcl,ptcl2,cache,rndstate,edep,eraddens,totevelo,ierr
 !
            if(lhelp) then
 !-- DDMC interface
-              mfphelp = (grd_cap(iiig,ic)+grd_sig(ic)) * &
-                   xm(ix)*dz(iz)*thelp
-              pp = 4d0/(3d0*mfphelp+6d0*pc_dext)
+              pp = ddmc_emiss_bc(xm(ix)*dz(iz)*thelp, grd_fcoef(ic), &
+                   grd_cap(iiig,ic), grd_sig(ic), pc_dext)
               resopacleak=.5d0*pp/(xm(ix)*dz(iz)*thelp)
            else
 !-- DDMC interior

--- a/TRANSPORT2/transport2.f90
+++ b/TRANSPORT2/transport2.f90
@@ -545,9 +545,8 @@ pure subroutine transport2(ptcl,ptcl2,rndstate,edep,eraddens,eamp,totevelo,ierr)
      else
 !-- DDMC in adjacent cell
         mu0 = sqrt(1d0-mu**2)*cos(om)
-        help = (grd_cap(ig,l)+grd_sig(l)) * &
-             dx(ixnext)*thelp
-        help = 4d0/(3d0*help+6d0*pc_dext)
+        help = ddmc_emiss_bc(dx(ixnext)*thelp, grd_fcoef(l), &
+             grd_cap(ig,l), grd_sig(l), pc_dext)
         help = help*(1d0 + 1.5d0*abs(mu0))
 !-- sampling
         call rnd_r(r1,rndstate)
@@ -583,9 +582,8 @@ pure subroutine transport2(ptcl,ptcl2,rndstate,edep,eraddens,eamp,totevelo,ierr)
         ic = grd_icell(ix,iy,iz)
      else
 !-- DDMC in adjacent cell
-        help = (grd_cap(ig,l)+grd_sig(l)) * &
-             dy(iynext)*thelp
-        help = 4d0/(3d0*help+6d0*pc_dext)
+        help = ddmc_emiss_bc(dy(iynext)*thelp, grd_fcoef(l), &
+             grd_cap(ig,l), grd_sig(l), pc_dext)
         help = help*(1d0 + 1.5d0*abs(mu))
 !-- sampling
         call rnd_r(r1,rndstate)
@@ -624,9 +622,8 @@ pure subroutine transport2(ptcl,ptcl2,rndstate,edep,eraddens,eamp,totevelo,ierr)
      else
 !-- DDMC in adjacent cell
         xi = sqrt(1d0-mu**2)*sin(om)
-        help = (grd_cap(ig,l)+grd_sig(l)) * &
-             xm(ix)*dz(iznext)*thelp
-        help = 4d0/(3d0*help+6d0*pc_dext)
+        help = ddmc_emiss_bc(xm(ix)*dz(iznext)*thelp, grd_fcoef(l), &
+             grd_cap(ig,l), grd_sig(l), pc_dext)
 !-- sampling
         call rnd_r(r1,rndstate)
         if (r1 < help*(1d0+1.5d0*abs(xi))) then

--- a/TRANSPORT3/diffusion3.f90
+++ b/TRANSPORT3/diffusion3.f90
@@ -203,14 +203,8 @@ pure subroutine diffusion3(ptcl,ptcl2,cache,rndstate,edep,eraddens,totevelo,ierr
      endif
      if(lhelp) then
 !-- DDMC interface
-        mfphelp = (grd_cap(ig,ic)+grd_sig(ic))*dx(ix)*thelp
-        alb = grd_fcoef(ic)*grd_cap(ig,ic)/ &
-             (grd_cap(ig,ic)+grd_sig(ic))
-        eps = (4d0/3d0)*sqrt(3d0*alb)/(1d0+pc_dext*sqrt(3d0*alb))
-        beta = 1.5d0*alb*mfphelp**2+sqrt(3d0*alb*mfphelp**2 + &
-             2.25d0*alb**2*mfphelp**4)
-        pp = 0.5d0*eps*beta/(beta-0.75*eps*mfphelp)
-!        pp = 4d0/(3d0*mfphelp+6d0*pc_dext)
+        pp = ddmc_emiss_bc(dx(ix)*thelp, grd_fcoef(ic), &
+             grd_cap(ig,ic), grd_sig(ic), pc_dext)
         opacleak(1)=0.5d0*pp/(thelp*dx(ix))
      else
 !-- DDMC interior
@@ -230,14 +224,8 @@ pure subroutine diffusion3(ptcl,ptcl2,cache,rndstate,edep,eraddens,totevelo,ierr
      endif
      if(lhelp) then
 !-- DDMC interface
-        mfphelp = (grd_cap(ig,ic)+grd_sig(ic))*dx(ix)*thelp
-        alb = grd_fcoef(ic)*grd_cap(ig,ic)/ &
-             (grd_cap(ig,ic)+grd_sig(ic))
-        eps = (4d0/3d0)*sqrt(3d0*alb)/(1d0+pc_dext*sqrt(3d0*alb))
-        beta = 1.5d0*alb*mfphelp**2+sqrt(3d0*alb*mfphelp**2 + &
-             2.25d0*alb**2*mfphelp**4)
-        pp = 0.5d0*eps*beta/(beta-0.75*eps*mfphelp)
-!        pp = 4d0/(3d0*mfphelp+6d0*pc_dext)
+        pp = ddmc_emiss_bc(dx(ix)*thelp, grd_fcoef(ic), &
+             grd_cap(ig,ic), grd_sig(ic), pc_dext)
         opacleak(2)=0.5d0*pp/(thelp*dx(ix))
      else
 !-- DDMC interior
@@ -257,14 +245,8 @@ pure subroutine diffusion3(ptcl,ptcl2,cache,rndstate,edep,eraddens,totevelo,ierr
      endif
      if(lhelp) then
 !-- DDMC interface
-        mfphelp = (grd_cap(ig,ic)+grd_sig(ic))*dy(iy)*thelp
-        alb = grd_fcoef(ic)*grd_cap(ig,ic)/ &
-             (grd_cap(ig,ic)+grd_sig(ic))
-        eps = (4d0/3d0)*sqrt(3d0*alb)/(1d0+pc_dext*sqrt(3d0*alb))
-        beta = 1.5d0*alb*mfphelp**2+sqrt(3d0*alb*mfphelp**2 + &
-             2.25d0*alb**2*mfphelp**4)
-        pp = 0.5d0*eps*beta/(beta-0.75*eps*mfphelp)
-!        pp = 4d0/(3d0*mfphelp+6d0*pc_dext)
+        pp = ddmc_emiss_bc(dy(iy)*thelp, grd_fcoef(ic), &
+             grd_cap(ig,ic), grd_sig(ic), pc_dext)
         opacleak(3)=0.5d0*pp/(thelp*dy(iy))
      else
 !-- DDMC interior
@@ -284,14 +266,8 @@ pure subroutine diffusion3(ptcl,ptcl2,cache,rndstate,edep,eraddens,totevelo,ierr
      endif
      if(lhelp) then
 !-- DDMC interface
-        mfphelp = (grd_cap(ig,ic)+grd_sig(ic))*dy(iy)*thelp
-        alb = grd_fcoef(ic)*grd_cap(ig,ic)/ &
-             (grd_cap(ig,ic)+grd_sig(ic))
-        eps = (4d0/3d0)*sqrt(3d0*alb)/(1d0+pc_dext*sqrt(3d0*alb))
-        beta = 1.5d0*alb*mfphelp**2+sqrt(3d0*alb*mfphelp**2 + &
-             2.25d0*alb**2*mfphelp**4)
-        pp = 0.5d0*eps*beta/(beta-0.75*eps*mfphelp)
-!        pp = 4d0/(3d0*mfphelp+6d0*pc_dext)
+        pp = ddmc_emiss_bc(dy(iy)*thelp, grd_fcoef(ic), &
+             grd_cap(ig,ic), grd_sig(ic), pc_dext)
         opacleak(4)=0.5d0*pp/(thelp*dy(iy))
      else
 !-- DDMC interior
@@ -311,14 +287,8 @@ pure subroutine diffusion3(ptcl,ptcl2,cache,rndstate,edep,eraddens,totevelo,ierr
      endif
      if(lhelp) then
 !-- DDMC interface
-        mfphelp = (grd_cap(ig,ic)+grd_sig(ic))*dz(iz)*thelp
-        alb = grd_fcoef(ic)*grd_cap(ig,ic)/ &
-             (grd_cap(ig,ic)+grd_sig(ic))
-        eps = (4d0/3d0)*sqrt(3d0*alb)/(1d0+pc_dext*sqrt(3d0*alb))
-        beta = 1.5d0*alb*mfphelp**2+sqrt(3d0*alb*mfphelp**2 + &
-             2.25d0*alb**2*mfphelp**4)
-        pp = 0.5d0*eps*beta/(beta-0.75*eps*mfphelp)
-!        pp = 4d0/(3d0*mfphelp+6d0*pc_dext)
+        pp = ddmc_emiss_bc(dz(iz)*thelp, grd_fcoef(ic), &
+             grd_cap(ig,ic), grd_sig(ic), pc_dext)
         opacleak(5)=0.5d0*pp/(thelp*dz(iz))
      else
 !-- DDMC interior
@@ -338,14 +308,8 @@ pure subroutine diffusion3(ptcl,ptcl2,cache,rndstate,edep,eraddens,totevelo,ierr
      endif
      if(lhelp) then
 !-- DDMC interface
-        mfphelp = (grd_cap(ig,ic)+grd_sig(ic))*dz(iz)*thelp
-        alb = grd_fcoef(ic)*grd_cap(ig,ic)/ &
-             (grd_cap(ig,ic)+grd_sig(ic))
-        eps = (4d0/3d0)*sqrt(3d0*alb)/(1d0+pc_dext*sqrt(3d0*alb))
-        beta = 1.5d0*alb*mfphelp**2+sqrt(3d0*alb*mfphelp**2 + &
-             2.25d0*alb**2*mfphelp**4)
-        pp = 0.5d0*eps*beta/(beta-0.75*eps*mfphelp)
-!        pp = 4d0/(3d0*mfphelp+6d0*pc_dext)
+        pp = ddmc_emiss_bc(dz(iz)*thelp, grd_fcoef(ic), &
+             grd_cap(ig,ic), grd_sig(ic), pc_dext)
         opacleak(6)=0.5d0*pp/(thelp*dz(iz))
      else
 !-- DDMC interior
@@ -522,15 +486,8 @@ pure subroutine diffusion3(ptcl,ptcl2,cache,rndstate,edep,eraddens,totevelo,ierr
            endif
            if(lhelp) then
 !-- IMC interface or boundary
-              mfphelp = (grd_cap(iiig,ic)+grd_sig(ic)) * &
-                   dx(ix)*thelp
-              alb = grd_fcoef(ic)*grd_cap(iiig,ic)/ &
-                   (grd_cap(iiig,ic)+grd_sig(ic))
-              eps = (4d0/3d0)*sqrt(3d0*alb)/(1d0+pc_dext*sqrt(3d0*alb))
-              beta = 1.5d0*alb*mfphelp**2+sqrt(3d0*alb*mfphelp**2 + &
-                   2.25d0*alb**2*mfphelp**4)
-              pp = 0.5d0*eps*beta/(beta-0.75*eps*mfphelp)
-!              pp = 4d0/(3d0*mfphelp+6d0*pc_dext)
+              pp = ddmc_emiss_bc(dx(ix)*thelp, grd_fcoef(ic), &
+                   grd_cap(iiig,ic), grd_sig(ic), pc_dext)
               resopacleak = 0.5d0*pp/(thelp*dx(ix))
            else
 !-- DDMC interface
@@ -639,15 +596,8 @@ pure subroutine diffusion3(ptcl,ptcl2,cache,rndstate,edep,eraddens,totevelo,ierr
            endif
            if(lhelp) then
 !-- IMC interface or boundary
-              mfphelp = (grd_cap(iiig,ic)+grd_sig(ic)) * &
-                   dx(ix)*thelp
-              alb = grd_fcoef(ic)*grd_cap(iiig,ic)/ &
-                   (grd_cap(iiig,ic)+grd_sig(ic))
-              eps = (4d0/3d0)*sqrt(3d0*alb)/(1d0+pc_dext*sqrt(3d0*alb))
-              beta = 1.5d0*alb*mfphelp**2+sqrt(3d0*alb*mfphelp**2 + &
-                   2.25d0*alb**2*mfphelp**4)
-              pp = 0.5d0*eps*beta/(beta-0.75*eps*mfphelp)
-!              pp = 4d0/(3d0*mfphelp+6d0*pc_dext)
+              pp = ddmc_emiss_bc(dx(ix)*thelp, grd_fcoef(ic), &
+                   grd_cap(iiig,ic), grd_sig(ic), pc_dext)
               resopacleak = 0.5d0*pp/(thelp*dx(ix))
            else
 !-- DDMC interface
@@ -754,15 +704,8 @@ pure subroutine diffusion3(ptcl,ptcl2,cache,rndstate,edep,eraddens,totevelo,ierr
            endif
            if(lhelp) then
 !-- IMC interface or boundary
-              mfphelp = (grd_cap(iiig,ic)+grd_sig(ic)) * &
-                   dy(iy)*thelp
-              alb = grd_fcoef(ic)*grd_cap(iiig,ic)/ &
-                   (grd_cap(iiig,ic)+grd_sig(ic))
-              eps = (4d0/3d0)*sqrt(3d0*alb)/(1d0+pc_dext*sqrt(3d0*alb))
-              beta = 1.5d0*alb*mfphelp**2+sqrt(3d0*alb*mfphelp**2 + &
-                   2.25d0*alb**2*mfphelp**4)
-              pp = 0.5d0*eps*beta/(beta-0.75*eps*mfphelp)
-!              pp = 4d0/(3d0*mfphelp+6d0*pc_dext)
+              pp = ddmc_emiss_bc(dy(iy)*thelp, grd_fcoef(ic), &
+                   grd_cap(iiig,ic), grd_sig(ic), pc_dext)
               resopacleak = 0.5d0*pp/(thelp*dy(iy))
            else
 !-- DDMC interface
@@ -870,15 +813,8 @@ pure subroutine diffusion3(ptcl,ptcl2,cache,rndstate,edep,eraddens,totevelo,ierr
            endif
            if(lhelp) then
 !-- IMC interface or boundary
-              mfphelp = (grd_cap(iiig,ic)+grd_sig(ic)) * &
-                   dy(iy)*thelp
-              alb = grd_fcoef(ic)*grd_cap(iiig,ic)/ &
-                   (grd_cap(iiig,ic)+grd_sig(ic))
-              eps = (4d0/3d0)*sqrt(3d0*alb)/(1d0+pc_dext*sqrt(3d0*alb))
-              beta = 1.5d0*alb*mfphelp**2+sqrt(3d0*alb*mfphelp**2 + &
-                   2.25d0*alb**2*mfphelp**4)
-              pp = 0.5d0*eps*beta/(beta-0.75*eps*mfphelp)
-!              pp = 4d0/(3d0*mfphelp+6d0*pc_dext)
+              pp = ddmc_emiss_bc(dy(iy)*thelp, grd_fcoef(ic), &
+                   grd_cap(iiig,ic), grd_sig(ic), pc_dext)
               resopacleak = 0.5d0*pp/(thelp*dy(iy))
            else
 !-- DDMC interface
@@ -986,15 +922,8 @@ pure subroutine diffusion3(ptcl,ptcl2,cache,rndstate,edep,eraddens,totevelo,ierr
            endif
            if(lhelp) then
 !-- IMC interface or boundary
-              mfphelp = (grd_cap(iiig,ic)+grd_sig(ic)) * &
-                   dz(iz)*thelp
-              alb = grd_fcoef(ic)*grd_cap(iiig,ic)/ &
-                   (grd_cap(iiig,ic)+grd_sig(ic))
-              eps = (4d0/3d0)*sqrt(3d0*alb)/(1d0+pc_dext*sqrt(3d0*alb))
-              beta = 1.5d0*alb*mfphelp**2+sqrt(3d0*alb*mfphelp**2 + &
-                   2.25d0*alb**2*mfphelp**4)
-              pp = 0.5d0*eps*beta/(beta-0.75*eps*mfphelp)
-!              pp = 4d0/(3d0*mfphelp+6d0*pc_dext)
+              pp = ddmc_emiss_bc(dz(iz)*thelp, grd_fcoef(ic), &
+                   grd_cap(iiig,ic), grd_sig(ic), pc_dext)
               resopacleak = 0.5d0*pp/(thelp*dz(iz))
            else
 !-- DDMC interface
@@ -1101,15 +1030,8 @@ pure subroutine diffusion3(ptcl,ptcl2,cache,rndstate,edep,eraddens,totevelo,ierr
            endif
            if(lhelp) then
 !-- IMC interface or boundary
-              mfphelp = (grd_cap(iiig,ic)+grd_sig(ic)) * &
-                   dz(iz)*thelp
-              alb = grd_fcoef(ic)*grd_cap(iiig,ic)/ &
-                   (grd_cap(iiig,ic)+grd_sig(ic))
-              eps = (4d0/3d0)*sqrt(3d0*alb)/(1d0+pc_dext*sqrt(3d0*alb))
-              beta = 1.5d0*alb*mfphelp**2+sqrt(3d0*alb*mfphelp**2 + &
-                   2.25d0*alb**2*mfphelp**4)
-              pp = 0.5d0*eps*beta/(beta-0.75*eps*mfphelp)
-!              pp = 4d0/(3d0*mfphelp+6d0*pc_dext)
+              pp = ddmc_emiss_bc(dz(iz)*thelp, grd_fcoef(ic), &
+                   grd_cap(iiig,ic), grd_sig(ic), pc_dext)
               resopacleak = 0.5d0*pp/(thelp*dz(iz))
            else
 !-- DDMC interface

--- a/TRANSPORT3/transport3.f90
+++ b/TRANSPORT3/transport3.f90
@@ -391,15 +391,8 @@ pure subroutine transport3(ptcl,ptcl2,rndstate,edep,eraddens,eamp,totevelo,ierr)
         ic = grd_icell(ix,iy,iz)
      else
 !-- DDMC in adjacent cell
-        help = (grd_cap(ig,l)+grd_sig(l)) * &
-             dx(ixnext)*thelp
-        alb = grd_fcoef(l)*grd_cap(ig,l)/ &
-             (grd_cap(ig,l)+grd_sig(l))
-        eps = (4d0/3d0)*sqrt(3d0*alb)/(1d0+pc_dext*sqrt(3d0*alb))
-        beta = 1.5d0*alb*help**2+sqrt(3d0*alb*help**2 + &
-             2.25d0*alb**2*help**4)
-        pp = 0.5d0*eps*beta/(beta-0.75*eps*help)
-        !pp = 4d0/(3d0*help+6d0*pc_dext)
+        pp = ddmc_emiss_bc(dx(ixnext)*thelp, grd_fcoef(l), &
+             grd_cap(ig,l), grd_sig(l), pc_dext)
 !-- sampling
         call rnd_r(r1,rndstate)
         if (r1 < pp * (1d0+1.5d0*abs(xi))) then
@@ -433,15 +426,8 @@ pure subroutine transport3(ptcl,ptcl2,rndstate,edep,eraddens,eamp,totevelo,ierr)
         ic = grd_icell(ix,iy,iz)
      else
 !-- DDMC in adjacent cell
-        help = (grd_cap(ig,l)+grd_sig(l)) * &
-             dy(iynext)*thelp
-        alb = grd_fcoef(l)*grd_cap(ig,l)/ &
-             (grd_cap(ig,l)+grd_sig(l))
-        eps = (4d0/3d0)*sqrt(3d0*alb)/(1d0+pc_dext*sqrt(3d0*alb))
-        beta = 1.5d0*alb*help**2+sqrt(3d0*alb*help**2 + &
-             2.25d0*alb**2*help**4)
-        pp = 0.5d0*eps*beta/(beta-0.75*eps*help)
-        !pp = 4d0/(3d0*help+6d0*pc_dext)
+        pp = ddmc_emiss_bc(dy(iynext)*thelp, grd_fcoef(l), &
+             grd_cap(ig,l), grd_sig(l), pc_dext)
 !-- sampling
         call rnd_r(r1,rndstate)
         if (r1 < pp * (1d0+1.5d0*abs(eta))) then
@@ -475,15 +461,8 @@ pure subroutine transport3(ptcl,ptcl2,rndstate,edep,eraddens,eamp,totevelo,ierr)
         ic = grd_icell(ix,iy,iz)
      else
 !-- DDMC in adjacent cell
-        help = (grd_cap(ig,l)+grd_sig(l)) * &
-             dz(iznext)*thelp
-        alb = grd_fcoef(l)*grd_cap(ig,l)/ &
-             (grd_cap(ig,l)+grd_sig(l))
-        eps = (4d0/3d0)*sqrt(3d0*alb)/(1d0+pc_dext*sqrt(3d0*alb))
-        beta = 1.5d0*alb*help**2+sqrt(3d0*alb*help**2 + &
-             2.25d0*alb**2*help**4)
-        pp = 0.5d0*eps*beta/(beta-0.75*eps*help)
-        !pp = 4d0/(3d0*help+6d0*pc_dext)
+        pp = ddmc_emiss_bc(dz(iznext)*thelp, grd_fcoef(l), &
+             grd_cap(ig,l), grd_sig(l), pc_dext)
         !-- sampling
         call rnd_r(r1,rndstate)
         if (r1 < pp * (1d0+1.5d0*abs(mu))) then

--- a/transportmod.f
+++ b/transportmod.f
@@ -398,5 +398,26 @@ c
       om0 = om
       end subroutine direction2lab3
 c
+c
+      elemental function ddmc_emiss_bc(dx, f, cap, sig, dext)
+c     -------------------------------------------------------
+      implicit none
+      real*8 :: ddmc_emiss_bc
+      real*4,intent(in) :: cap
+      real*8,intent(in) :: dx, f, sig, dext
+************************************************************************
+* See Densmore, Davidson and Carrington (2006)
+************************************************************************
+      real*8 :: help, alb, eps, beta
+      help = (cap+sig)*dx
+      alb = f*cap / (cap+sig)
+      eps = (4d0/3d0)*sqrt(3d0*alb)/(1d0+dext*sqrt(3d0*alb))
+      beta = 1.5d0*alb*help**2+sqrt(3d0*alb*help**2 +
+     &     2.25d0*alb**2*help**4)
+      ddmc_emiss_bc = 0.5d0*eps*beta/(beta-0.75*eps*help)
+c
+      end function ddmc_emiss_bc
+c
+c
       end module transportmod
 c vim: fdm=marker


### PR DESCRIPTION
### Background

* The IMC-DDMC interface condition in SuperNu currently has two formulae.
* The more accurate one, currently used in 3D planar geometry, is from [Densmore, Davidson and Carrington (2006)](https://www.sciencedirect.com/science/article/pii/S0306454906000338)

### Description

+ Add pure function with emissivity formula to transportmod.
+ Use in 1D/3D spherical, 3D cylindrical, and 3D planar geometry.