### PR TITLE
Attempt more judicious use of Saha-Boltzmann-derived ion-electron state.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ option (USE_OPENMP "USE_OPENMP" OFF)
 
 #-- name the project and set the language
 project (SuperNu)
-set (SuperNu_VERSION_MAJOR 3)
+set (SuperNu_VERSION_MAJOR 4)
 set (SuperNu_VERSION_MINOR "x")
 enable_language (Fortran)
 

--- a/GAS/gas_update.f
+++ b/GAS/gas_update.f
@@ -190,10 +190,11 @@ c-- calculate power law heat capacity
        gas_bcoef = in_gas_cvcoef * gas_temp**in_gas_cvtpwr *
      &   gas_rho**in_gas_cvrpwr
       else
-!-- calculate physical heat capacity
-       if(.not.in_notbopac) then
+c-- calculate physical heat capacity
+       if(in_noeos) then
          gas_bcoef = 1.5d0*pc_kb*gas_natom/gas_vol
        else
+c-- add free electron contribution if physical EOS was used
          gas_bcoef = 1.5d0*pc_kb*(1d0+gas_nelec)*gas_natom /
      &      gas_vol
        endif

--- a/inputparmod.f
+++ b/inputparmod.f
@@ -670,10 +670,13 @@ c
 c
       select case(in_opacanaltype)
       case('none')
-c--R.W.: condition under case(pick) supposed to be here? (rev 243)
+c-- check at least one opacity contribution is used
        if(in_nobbopac.and.in_nobfopac.and.in_noffopac.and.
      &    in_notbbbopac.and.in_notbbfopac.and.in_notbffopac)
      &        stop 'no phys opac + in_opacanaltype==none'
+c-- if tabular opacity not being used then inline is used, so EOS needed
+       if(in_notbopac.and.in_noeos)
+     &      stop 'inline phys opac, but in_noeos=t'
       case('grey')
       case('mono')
       case('pick')

--- a/mpimod_mpi.f
+++ b/mpimod_mpi.f
@@ -188,7 +188,10 @@ c-- free-free
       call mpi_bcast(ff_gff,ff_nu*ff_ngg,MPI_REAL8,
      &  impi0,MPI_COMM_WORLD,ierr)
 c
-      call bcast_ions
+c-- only bcast ion structure when using physical EOS
+      if (.not.in_noeos) then
+        call bcast_ions
+      endif
 c
 c
       contains

--- a/supernu.f90
+++ b/supernu.f90
@@ -86,7 +86,9 @@ program supernu
 
 !-- READ DATA
 !-- read ion and level data
-     call ions_read_data(gas_nelem)  !ion and level data
+     if(.not.in_noeos) then
+       call ions_read_data(gas_nelem)  !ion and level data
+     endif
 !-- read bbxs data
      if(.not.in_nobbopac) call read_bbxs_data(gas_nelem)!bound-bound cross section data
 !-- read bfxs data
@@ -144,7 +146,9 @@ program supernu
   call sourcemod_init(nmpi)
 
 !-- allocate arrays of sizes retreived in bcast_permanent
-  call ions_alloc_grndlev(gas_nelem,gas_ncell)  !ground state occupation numbers
+  if (.not.in_noeos) then
+     call ions_alloc_grndlev(gas_nelem,gas_ncell)  !ground state occupation numbers
+  endif
   call particle_alloc(lmpi0)
 
 !-- initialize random number generator, use different seeds for each rank


### PR DESCRIPTION
## Background

* Some clean up attempting to better control activation of Saha-Boltzmann related quantities is in order.
* For instance, we do not want to MPI send the complicated `ion_el` data structure when it is not used.

## Changes

+ Disable parsing data.ion and constructing ion_el when in_noeos=f.
+ Disable MPI sending and allocating ion_el when in_noeos=f.
+ Assert in_noeos=t when using inline physical opacity.
+ Replace in_notbopac with in_noeos in using free electrons in Cv.
+ Update SuperNu version in cmake configuration banner.