### PR TITLE
Update to cmake build instruction in README, rename to README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,18 @@ CODING STANDARDS
 
 SETUP INSTRUCTIONS
 ==================
-TODO: update this with CMake instructions
+
+Starting from the source directory:
+```bash
+pwd                # should show <path>/<to>/supernu
+cd ..
+mkdir build
+cd build
+cmake ../supernu
+ccmake .           # (optionally) change configuration options
+make -j
+```
+The supernu executable should now be in the 'build' directory.
 
 
 USE INSTRUCTIONS


### PR DESCRIPTION
## Background

* The `README` should have been updated after removal of the older Makefile build method.

## Changes

* Add cmake build instructions to `README`.
* Rename `README` to `README.md`, in anticipation of using more markdown.

## Merge Requirements

- [ ] Verify compilation.
- [x] No "Draft" designation.
- [ ] Approved by a reviewer.
