### PR TITLE
Fix a memory leak (allocation without deallocation).

### DIFF
--- a/SOURCE/interior_source.f90
+++ b/SOURCE/interior_source.f90
@@ -22,6 +22,7 @@ subroutine interior_source
   use inputparmod
   use manufacmod
   use countersmod
+  use mpimod, only:nmpi
 
   implicit none
 
@@ -32,7 +33,7 @@ subroutine interior_source
 !##################################################
   integer :: i,j,k, ipart,ivac,ig,ii
   integer :: nhere,ndmy,iimpi,nemit
-  integer*8,allocatable :: nvacantall(:)
+  integer*8 :: nvacantall(nmpi)
   real*8 :: pwr
   real*8 :: r1, r2, r3, uul, uur, uumax
   real*8 :: om0, mu0, x0, ep0, wl0
@@ -58,8 +59,6 @@ subroutine interior_source
 
   x1=grp_wlinv(grp_ng+1)
   x2=grp_wlinv(1)
-
-  allocate(nvacantall(size(src_nvacantall)))
 
 !Volume particle instantiation: loop
 !Loop run over the number of new particles that aren't surface source
@@ -150,6 +149,7 @@ subroutine interior_source
 
 !-- Thermal volume particle instantiation: loop
   iimpi = -1
+!-- reset local vacancy count per rank
   nvacantall = src_nvacantall
   do k=1,grd_nz
   do j=1,grd_ny

--- a/SOURCE/sourcenumbers.f90
+++ b/SOURCE/sourcenumbers.f90
@@ -28,7 +28,6 @@ subroutine sourcenumbers(keephigh)
   integer*8 :: n,ndone
   integer :: nextra,nsmean
   integer*8 :: nvacant(nmpi)
-  real*8,parameter :: basefrac=.1d0
   integer*8 :: nstot,nstotd,nsavail
   integer*8 :: nvacantall,nnewvacant
   integer*8 :: ncactive
@@ -167,7 +166,7 @@ subroutine sourcenumbers_roundrobin_limit(iimpi,nvacant,evol,evolex,ntot,mvol,nv
      return
   endif
 !
-!-- 
+!--
   help = evol/(evol + evolex)
   mvol = nint(ntot*help)
   nvolex = ntot - mvol
@@ -260,7 +259,7 @@ subroutine sourcenumbers_roundrobin(iimpi,evol,evolex,ntot,mvol,nvol,nvolex)
      return
   endif
 !
-!-- 
+!--
   help = evol/(evol + evolex)
   mvol = nint(ntot*help)
   nvolex = ntot - mvol

--- a/supernu.f90
+++ b/supernu.f90
@@ -231,7 +231,7 @@ program supernu
 
 !-- source energy
      call sourceenergy_misc(lmpi0)      !add gamma source energy and amplification-factor energy
-     call sourceenergy_analytic(lmpi0)  !gas_emitex from analytic distribution
+     call sourceenergy_analytic(lmpi0)  !gas_emitex reset to 0 or to an analytic distribution
 
      call leakage_opacity       !IMC-DDMC albedo coefficients and DDMC leakage opacities
      call emission_probability  !emission probabilities for ep-group in each cell


### PR DESCRIPTION
## Background

* `interior_source` uses a locally defined heap array to pass as an argument to MPI round-robin particle accounting.
* The allocation is not paired with a deallocation. 

## Changes

+ Change interior_source nvacantall array from heap to stack memory.
+ Remove unused variable in sourcenumbers.

## Merge Requirements

- [x] Verify compilation.
- [x] No "Draft" designation.
- [x] Approved by a reviewer.
